### PR TITLE
Position shadow DOM elements on the screen

### DIFF
--- a/Plugins/QuorumPlugins/src/main/java/plugins/quorum/Libraries/Interface/Accessibility/AndroidAccessibility.java
+++ b/Plugins/QuorumPlugins/src/main/java/plugins/quorum/Libraries/Interface/Accessibility/AndroidAccessibility.java
@@ -25,6 +25,8 @@ public class AndroidAccessibility {
 
     public void  DescriptionChanged(Item_ item) {}
 
+    public void  BoundsChanged(Item_ item) {}
+
     public void  TextFieldUpdatePassword(TextField_ field) {}
 
     public void  Update() {}

--- a/Plugins/QuorumPlugins/src/main/java/plugins/quorum/Libraries/Interface/Accessibility/MacAccessibility.java
+++ b/Plugins/QuorumPlugins/src/main/java/plugins/quorum/Libraries/Interface/Accessibility/MacAccessibility.java
@@ -64,6 +64,8 @@ public class MacAccessibility {
 
     public void  DescriptionChanged(Item_ item) {}
 
+    public void  BoundsChanged(Item_ item) {}
+
     public void  TextFieldUpdatePassword(TextField_ field) {}
 
     public void  Update() {}

--- a/Plugins/QuorumPlugins/src/main/java/plugins/quorum/Libraries/Interface/AccessibilityManager.java
+++ b/Plugins/QuorumPlugins/src/main/java/plugins/quorum/Libraries/Interface/AccessibilityManager.java
@@ -756,6 +756,8 @@ public class AccessibilityManager
         DescriptionChangedNative(nativePointer, item.GetDescription());
     }
     
+    public void BoundsChanged(Item_ item) {}
+    
     public boolean OnButtonActivation(Button_ button)
     {
         if (ITEM_MAP.containsKey(button) == false)

--- a/Quorum/Library/Standard/Libraries/Game/Game.quorum
+++ b/Quorum/Library/Standard/Libraries/Game/Game.quorum
@@ -1881,7 +1881,7 @@ class Game
 
         action Main
             WebConfiguration configuration
-            configuration:canvasID = "game-canvas"
+            configuration:containerID = "game-container"
             configuration:capFramesPerSecond = true
             configuration:framesPerSecondLimit = 45
             SetConfiguration(configuration)
@@ -4580,14 +4580,14 @@ class Game
     end
 
     /*
-    The SetWebCanvasName action determines which canvas to use on a webpage.
-    When the game runs, it will be displayed on the designated canvas. If no
-    canvas name is given, the engine will attempt to find a canvas with the
-    default name, "QuorumGraphicsCanvas". If the engine can't find a canvas with
-    the set name, it will not run. This action has no effect if called inside a
+    The SetWebContainerID action determines which container to use on a webpage.
+    When the game runs, it will be displayed in the designated container. If no
+    container ID is given, the engine will attempt to find a container with the
+    default ID, "QuorumUIContainer". If the engine can't find a container with
+    the set ID, it will not run. This action has no effect if called inside a
     game that isn't being run online.
 
-    Attribute: Parameter name The name of the canvas to display graphics on.
+    Attribute: Parameter id The ID of the canvas to display the game in.
     
     Attribute: Example
 
@@ -4597,14 +4597,14 @@ class Game
     class Main is Game
 
         action Main
-            SetWebCanvasName("myCanvas")
+            SetWebContainerID("myContainer")
             StartGame()
         end
     end
     */
-    action SetWebCanvasName(text name)
+    action SetWebContainerID(text id)
         WebConfiguration config = GetWebConfiguration()
-        config:canvasID = name
+        config:containerID = id
     end
 
     /*

--- a/Quorum/Library/Standard/Libraries/Game/Layer2D.quorum
+++ b/Quorum/Library/Standard/Libraries/Game/Layer2D.quorum
@@ -138,6 +138,7 @@ class Layer2D is Layer
         OrthographicCamera cam
         camera = cam
         SetViewport(0, 0, manager:GetGameDisplay():GetWidth(), manager:GetGameDisplay():GetHeight())
+        camera:Update()
         collisionManager:SetLayer(me)
 
         graphics = manager:GetGameGraphics()    

--- a/Quorum/Library/Standard/Libraries/Game/WebConfiguration.quorum
+++ b/Quorum/Library/Standard/Libraries/Game/WebConfiguration.quorum
@@ -5,9 +5,9 @@ use Libraries.Game.ApplicationConfiguration
 class WebConfiguration is ApplicationConfiguration
 
     /*
-    The ID of the canvas to use for rendering the Game.
+    The ID of the pre-existing element that contains the UI.
     */
-    public text canvasID = "QuorumGraphicsCanvas"
+    public text containerID = "QuorumUIContainer"
 
     /*
     Whether or not the Game should be limited to the given number of frames per

--- a/Quorum/Library/Standard/Libraries/Interface/Accessibility.quorum
+++ b/Quorum/Library/Standard/Libraries/Interface/Accessibility.quorum
@@ -41,6 +41,13 @@ class Accessibility
     blueprint action DescriptionChanged(Item item)
 
     /*
+        This action indicates that an item's position and/or size changed.
+
+        Attribute: Parameter item the item that changed.
+    */
+    blueprint action BoundsChanged(Item item)
+
+    /*
         This action indicates that a text field in password mode had its value changed.
 
         Attribute: Parameter field a particular field that had its password changed.

--- a/Quorum/Library/Standard/Libraries/Interface/Accessibility/AndroidAccessibility.quorum
+++ b/Quorum/Library/Standard/Libraries/Interface/Accessibility/AndroidAccessibility.quorum
@@ -21,6 +21,8 @@ class AndroidAccessibility is Accessibility
 
     system action DescriptionChanged(Item item)
 
+    system action BoundsChanged(Item item)
+
     system action TextFieldUpdatePassword(TextField field)
 
     system action Update

--- a/Quorum/Library/Standard/Libraries/Interface/Accessibility/MacAccessibility.quorum
+++ b/Quorum/Library/Standard/Libraries/Interface/Accessibility/MacAccessibility.quorum
@@ -21,6 +21,8 @@ class MacAccessibility is Accessibility
 
     system action DescriptionChanged(Item item)
 
+    system action BoundsChanged(Item item)
+
     system action TextFieldUpdatePassword(TextField field)
 
     system action Update

--- a/Quorum/Library/Standard/Libraries/Interface/Accessibility/WebAccessibility.quorum
+++ b/Quorum/Library/Standard/Libraries/Interface/Accessibility/WebAccessibility.quorum
@@ -45,6 +45,8 @@ class WebAccessibility is Accessibility
 
     system action DescriptionChanged(Item item)
 
+    system action BoundsChanged(Item item)
+
     system action TextFieldUpdatePassword(TextField field)
 
     private system action TextSelectionChanged(TextBoxSelection selection)

--- a/Quorum/Library/Standard/Libraries/Interface/AccessibilityManager.quorum
+++ b/Quorum/Library/Standard/Libraries/Interface/AccessibilityManager.quorum
@@ -102,6 +102,8 @@ class AccessibilityManager is Accessibility
 
     system action DescriptionChanged(Item item)
 
+    system action BoundsChanged(Item item)
+
     system action TextFieldUpdatePassword(TextField field)
 
     // A constant used with the Notify action, indicating that the program had to abort some process.

--- a/Quorum/Library/Standard/Libraries/Interface/Item2D.quorum
+++ b/Quorum/Library/Standard/Libraries/Interface/Item2D.quorum
@@ -254,6 +254,13 @@ class Item2D is Item
         scale:Set(1, 1)
     end
 
+    private action NotifyAccessibilityBoundsChanged
+        Accessibility accessibility = manager:GetAccessibility()
+        if accessibility not= undefined
+            accessibility:BoundsChanged(me)
+        end
+    end
+
     /*
     This action sets the X coordinate of the Item.
 
@@ -279,6 +286,8 @@ class Item2D is Item
         if physicsEnabled and not IsSimulated() and shouldTriggerSimulation
             Simulate(true)
         end
+
+        NotifyAccessibilityBoundsChanged()
     end
 
     /*
@@ -306,6 +315,8 @@ class Item2D is Item
         if physicsEnabled and not IsSimulated() and shouldTriggerSimulation
             Simulate(true)
         end
+
+        NotifyAccessibilityBoundsChanged()
     end
 
     /*
@@ -330,6 +341,8 @@ class Item2D is Item
         if visualView not= undefined
             visualView:UpdatePosition(GetGlobalX(), GetGlobalY(), GetGlobalZ())
         end
+
+        NotifyAccessibilityBoundsChanged()
     end
 
     /*
@@ -399,6 +412,8 @@ class Item2D is Item
         if physicsEnabled and not IsSimulated() and shouldTriggerSimulation
             Simulate(true)
         end
+
+        NotifyAccessibilityBoundsChanged()
     end
 
     /*
@@ -453,6 +468,8 @@ class Item2D is Item
             drawShape:SetWidth(newWidth)
         end
 
+        NotifyAccessibilityBoundsChanged()
+
         Resize()
     end
 
@@ -487,6 +504,8 @@ class Item2D is Item
         if drawShape not= undefined
             drawShape:SetHeight(newHeight)
         end
+
+        NotifyAccessibilityBoundsChanged()
         
         Resize()
     end
@@ -633,6 +652,8 @@ class Item2D is Item
             visualView:UpdatePosition(GetGlobalX(), GetGlobalY(), GetGlobalZ())
         end
 
+        NotifyAccessibilityBoundsChanged()
+
         integer counter = 0
         repeat children:GetSize() times
             children:Get(counter):SetOffsetX(position:GetX() + xAmount)
@@ -670,6 +691,8 @@ class Item2D is Item
             visualView:UpdatePosition(GetGlobalX(), GetGlobalY(), GetGlobalZ())
         end
 
+        NotifyAccessibilityBoundsChanged()
+
         integer counter = 0
         repeat children:GetSize() times
             children:Get(counter):SetOffsetY(position:GetY() + yAmount)
@@ -702,6 +725,8 @@ class Item2D is Item
         if visualView not= undefined
             visualView:UpdatePosition(GetGlobalX(), GetGlobalY(), GetGlobalZ())
         end
+
+        NotifyAccessibilityBoundsChanged()
 
         integer counter = 0
         repeat children:GetSize() times
@@ -790,6 +815,8 @@ class Item2D is Item
             visualView:UpdatePosition(GetGlobalX(), GetGlobalY(), GetGlobalZ())
         end
 
+        NotifyAccessibilityBoundsChanged()
+
         integer counter = 0
         repeat children:GetSize() times
             children:Get(counter):SetOffset(position:GetX() + xAmount, position:GetY() + yAmount)
@@ -824,6 +851,8 @@ class Item2D is Item
         if visualView not= undefined
             visualView:UpdatePosition(GetGlobalX(), GetGlobalY(), GetGlobalZ())
         end
+
+        NotifyAccessibilityBoundsChanged()
 
         integer counter = 0
         repeat children:GetSize() times
@@ -907,6 +936,8 @@ class Item2D is Item
             drawShape:SetSize(newWidth, newHeight)
         end
 
+        NotifyAccessibilityBoundsChanged()
+
         Resize()
     end
 
@@ -938,6 +969,8 @@ class Item2D is Item
         if physicsEnabled and not IsSimulated() and shouldTriggerSimulation
             Simulate(true)
         end
+
+        NotifyAccessibilityBoundsChanged()
     end
 
     /*
@@ -968,6 +1001,8 @@ class Item2D is Item
         if physicsEnabled and not IsSimulated() and shouldTriggerSimulation
             Simulate(true)
         end
+
+        NotifyAccessibilityBoundsChanged()
     end
 
     /*
@@ -993,6 +1028,8 @@ class Item2D is Item
         if visualView not= undefined
             visualView:UpdatePosition(GetGlobalX(), GetGlobalY(), GetGlobalZ())
         end
+
+        NotifyAccessibilityBoundsChanged()
     end
 
     /*
@@ -1045,6 +1082,8 @@ class Item2D is Item
         if physicsEnabled and not IsSimulated() and shouldTriggerSimulation
             Simulate(true)
         end
+
+        NotifyAccessibilityBoundsChanged()
     end
 
     /*
@@ -1101,6 +1140,8 @@ class Item2D is Item
             visualView:UpdateFlipping(flipX, flipY)
         end
 
+        NotifyAccessibilityBoundsChanged()
+
         integer counter = 0
         repeat children:GetSize() times
             children:Get(counter):FlipX()
@@ -1125,6 +1166,8 @@ class Item2D is Item
         if visualView not= undefined
             visualView:UpdateFlipping(flipX, flipY)
         end
+
+        NotifyAccessibilityBoundsChanged()
 
         integer counter = 0
         repeat children:GetSize() times
@@ -1795,6 +1838,8 @@ class Item2D is Item
         if drawShape not= undefined
             drawShape:RequestUpdate()
         end
+
+        NotifyAccessibilityBoundsChanged()
     end
 
     /*
@@ -1817,6 +1862,8 @@ class Item2D is Item
         if drawShape not= undefined
             drawShape:RequestUpdate()
         end
+
+        NotifyAccessibilityBoundsChanged()
     end
 
     /*
@@ -1848,6 +1895,8 @@ class Item2D is Item
         if visualView not= undefined
             visualView:UpdateRotation(rotation)
         end
+
+        NotifyAccessibilityBoundsChanged()
 
         if children:GetSize() > 0
 
@@ -2014,6 +2063,8 @@ class Item2D is Item
             visualView:UpdateSize(GetWidth() * GetScaleX(), GetHeight() * GetScaleY())
         end
 
+        NotifyAccessibilityBoundsChanged()
+
         Resize()
 
         
@@ -2078,6 +2129,8 @@ class Item2D is Item
         if visualView not= undefined
             visualView:UpdateSize(GetWidth() * GetScaleX(), GetHeight() * GetScaleY())
         end
+
+        NotifyAccessibilityBoundsChanged()
 
         Resize()
 
@@ -2183,6 +2236,8 @@ class Item2D is Item
             visualView:UpdateSize(GetWidth() * GetScaleX(), GetHeight() * GetScaleY())
         end
 
+        NotifyAccessibilityBoundsChanged()
+
         Resize()
 
         Iterator<Item2D> childIterator = GetItems()
@@ -2268,6 +2323,8 @@ class Item2D is Item
         if visualView not= undefined
             visualView:UpdateSize(GetWidth() * GetScaleX(), GetHeight() * GetScaleY())
         end
+
+        NotifyAccessibilityBoundsChanged()
 
         Resize()
 

--- a/Quorum/Library/Standard/Libraries/Language/Compile/Compiler.quorum
+++ b/Quorum/Library/Standard/Libraries/Language/Compile/Compiler.quorum
@@ -689,14 +689,22 @@ There are many ways to load canvases and this is provided only as an exemplar.
         <title>Test Web Application</title>
         <meta charset=" + dq + "UTF-8" + dq + ">
         <meta name="+ dq +"viewport" + dq +"content="+ dq +"width=device-width, initial-scale=1.0"+ dq +">
+        <style>
+            html, body, #QuorumUIRoot {
+                position: absolute;
+                left: 0;
+                bottom: 0;
+                width: 100%;
+                height: 100%;
+                margin: 0;
+                padding: 0;
+            }
+        </style>
         <script src = "+ dq +"QuorumStandardLibrary.js"+ dq +"></script>
         <script src = "+ dq + GetName() + ".js"+ dq +"></script>
     </head>
     <body>
-        <canvas id="+ dq +"QuorumGraphicsCanvas"+ dq +" width="+ dq +"800"+ dq +" height="+ dq +"600"+ dq +" tabindex="+ dq +"0"+ dq +" style="+ dq +"outline: none"+ dq +">
-            Your browser doesn't appear to support the 
-            <code>&lt;canvas&gt;</code> element.
-        </canvas>
+        <div id="+ dq +"QuorumUIContainer"+ dq +" tabindex="+ dq +"0"+ dq +"></div>
         <script type="+ dq +"text/javascript"+ dq +">
             var Module = {
                 onRuntimeInitialized: function () {

--- a/Quorum/Library/Standard/Libraries/Language/Compile/Compiler.quorum
+++ b/Quorum/Library/Standard/Libraries/Language/Compile/Compiler.quorum
@@ -704,7 +704,7 @@ There are many ways to load canvases and this is provided only as an exemplar.
         <script src = "+ dq + GetName() + ".js"+ dq +"></script>
     </head>
     <body>
-        <div id="+ dq +"QuorumUIContainer"+ dq +" tabindex="+ dq +"0"+ dq +"></div>
+        <div id="+ dq +"QuorumUIContainer"+ dq +"></div>
         <script type="+ dq +"text/javascript"+ dq +">
             var Module = {
                 onRuntimeInitialized: function () {

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/InputMonitor.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/InputMonitor.js
@@ -2,7 +2,7 @@ function plugins_quorum_Libraries_Game_InputMonitor_()
 {
     this.IsKeyPressed$quorum_integer = function(keyCode)
     {
-        if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsCanvasFocused())
+        if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsFocused())
             return plugins_quorum_Libraries_Game_WebInput_.pressedKeys[keyCode] === true;
 
         return false;
@@ -10,7 +10,7 @@ function plugins_quorum_Libraries_Game_InputMonitor_()
     
     this.IsMouseButtonPressed$quorum_integer = function(buttonCode)
     {
-        if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsCanvasFocused())
+        if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsFocused())
         {
             var buttons = plugins_quorum_Libraries_Game_WebInput_.mouseInfo.buttons;
             switch (buttonCode)
@@ -55,7 +55,7 @@ function plugins_quorum_Libraries_Game_InputMonitor_()
     
     this.IsClicked = function()
     {
-        if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsCanvasFocused())
+        if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsFocused())
             return plugins_quorum_Libraries_Game_WebInput_.mouseInfo.buttons > 0;
     };
     

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebDisplay.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebDisplay.js
@@ -29,6 +29,9 @@ function plugins_quorum_Libraries_Game_WebDisplay_()
         }
         container = document.getElementById(id);
 
+        container.setAttribute("tabindex", "0");
+        container.setAttribute("role", "application");
+
         canvas = document.createElement("canvas");
         canvas.setAttribute("aria-hidden", "true");
         canvas.style.outline = "none";

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebDisplay.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebDisplay.js
@@ -1,6 +1,7 @@
 function plugins_quorum_Libraries_Game_WebDisplay_() 
 {
-    var canvas = null;
+    let container = null;
+    let canvas = null;
     var configuration = null;
     
     var lastTime = 0;
@@ -20,18 +21,23 @@ function plugins_quorum_Libraries_Game_WebDisplay_()
     
     this.SetupDisplay = function()
     {
-        if (typeof currentIDECanvas_$Global_ !== 'undefined') {
-            canvas = document.getElementById(currentIDECanvas_$Global_);
+        let id;
+        if (typeof currentUIContainer_$Global_ !== "undefined") {
+            id = currentUIContainer_$Global_;
         } else {
-            var id = configuration.canvasID;
-            currentIDECanvas_$Global_ = id;
-            canvas = document.getElementById(id);
+            id = configuration.containerID;
         }
+        container = document.getElementById(id);
 
-        // This doesn't affect the position of the canvas, but it enables
-        // accessibility elements to be positioned relative to the canvas.
-        canvas.style.position = "relative";
-        canvas.style.overflow = "hidden";
+        canvas = document.createElement("canvas");
+        canvas.setAttribute("aria-hidden", "true");
+        canvas.style.outline = "none";
+        canvas.style.position = "absolute";
+        canvas.style.left = 0;
+        canvas.style.top = 0;
+        canvas.style.width = "100%";
+        canvas.style.height = "100%";
+        container.appendChild(canvas);
     };
     
     this.GetCanvas = function()
@@ -39,11 +45,16 @@ function plugins_quorum_Libraries_Game_WebDisplay_()
         return canvas;
     };
     
-    this.IsCanvasFocused = function()
+    this.GetContainer = function()
+    {
+        return container;
+    };
+    
+    this.IsFocused = function()
     {
         let element = document.activeElement;
         while (element) {
-            if (element === canvas) {
+            if (element === container) {
                 return true;
             }
             element = element.parentElement;
@@ -53,11 +64,7 @@ function plugins_quorum_Libraries_Game_WebDisplay_()
     
     this.SetDisplayMode$quorum_integer$quorum_integer$quorum_boolean = function(width, height, fullscreen)
     {
-        // Currently resizes canvas but does not support fullscreen.
-        canvas.width = width;
-        canvas.height = height;
-        
-        return canvas.width === width && canvas.height === height && !fullscreen;
+        throw new Error("Not supported on the web platform; the size is defined by the container.");
     };
     
     this.GetWidth = function()

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebDisplay.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebDisplay.js
@@ -27,6 +27,11 @@ function plugins_quorum_Libraries_Game_WebDisplay_()
             currentIDECanvas_$Global_ = id;
             canvas = document.getElementById(id);
         }
+
+        // This doesn't affect the position of the canvas, but it enables
+        // accessibility elements to be positioned relative to the canvas.
+        canvas.style.position = "relative";
+        canvas.style.overflow = "hidden";
     };
     
     this.GetCanvas = function()

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebInput.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebInput.js
@@ -16,7 +16,7 @@ function plugins_quorum_Libraries_Game_WebInput_()
         
         plugins_quorum_Libraries_Game_WebInput_.KeyDown = function(event)
         {
-            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsCanvasFocused())
+            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsFocused())
             {
                 var quorumEvent = plugins_quorum_Libraries_Game_WebInput_.ConvertToQuorumKeyEvent(event, true);
                 if (!plugins_quorum_Libraries_Game_WebInput_.pressedKeys[quorumEvent.Get_Libraries_Interface_Events_KeyboardEvent__keyCode_()])
@@ -30,7 +30,7 @@ function plugins_quorum_Libraries_Game_WebInput_()
         
         plugins_quorum_Libraries_Game_WebInput_.KeyUp = function(event)
         {
-            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsCanvasFocused())
+            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsFocused())
             {
                 if (event.code === "Escape" && plugins_quorum_Libraries_Game_WebInput_.keepTabFocus())
                 {
@@ -60,7 +60,7 @@ function plugins_quorum_Libraries_Game_WebInput_()
         public constant integer SCROLLED_MOUSE = 5
         */
 
-        const isMouseInCanvas = function(event)
+        plugins_quorum_Libraries_Game_WebInput_.IsMouseInCanvas = function(event)
         {
             var canvas = plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.GetCanvas();
             var rect = canvas.getBoundingClientRect();
@@ -75,7 +75,7 @@ function plugins_quorum_Libraries_Game_WebInput_()
              * window focus) to trigger a mouse event, and prevents clicks from
              * outside the window being captured.
              */
-            if (isMouseInCanvas(event))
+            if (plugins_quorum_Libraries_Game_WebInput_.IsMouseInCanvas(event))
             {
                 event.stopPropagation();
                 event.preventDefault();
@@ -86,13 +86,13 @@ function plugins_quorum_Libraries_Game_WebInput_()
         
         plugins_quorum_Libraries_Game_WebInput_.MouseUp = function(event)
         {
-            if (isMouseInCanvas(event))
+            if (plugins_quorum_Libraries_Game_WebInput_.IsMouseInCanvas(event))
             {
                 event.stopPropagation();
                 event.preventDefault();
             }
 
-            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsCanvasFocused())
+            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsFocused())
             {
                 var quorumEvent = plugins_quorum_Libraries_Game_WebInput_.ConvertToQuorumMouseEvent(event, 4);
                 plugins_quorum_Libraries_Game_WebInput_.mouseEvents.push(quorumEvent);
@@ -101,13 +101,13 @@ function plugins_quorum_Libraries_Game_WebInput_()
         
         plugins_quorum_Libraries_Game_WebInput_.MouseMove = function(event)
         {
-            if (isMouseInCanvas(event))
+            if (plugins_quorum_Libraries_Game_WebInput_.IsMouseInCanvas(event))
             {
                 event.stopPropagation();
                 event.preventDefault();
             }
 
-            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsCanvasFocused())
+            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsFocused())
             {
                 // If no mouse buttons pressed, send code for MOVED_MOUSE. Otherwise, send DRAGGED_MOUSE.
                 var quorumEvent = plugins_quorum_Libraries_Game_WebInput_.ConvertToQuorumMouseEvent(event, event.buttons > 0 ? 3 : 2);
@@ -117,13 +117,13 @@ function plugins_quorum_Libraries_Game_WebInput_()
         
         plugins_quorum_Libraries_Game_WebInput_.MouseScroll = function(event)
         {
-            if (isMouseInCanvas(event))
+            if (plugins_quorum_Libraries_Game_WebInput_.IsMouseInCanvas(event))
             {
                 event.stopPropagation();
                 event.preventDefault();
             }
 
-            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsCanvasFocused())
+            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsFocused())
             {
                 var quorumEvent = plugins_quorum_Libraries_Game_WebInput_.ConvertToQuorumMouseEvent(event, 5);
                 plugins_quorum_Libraries_Game_WebInput_.mouseEvents.push(quorumEvent);
@@ -132,7 +132,7 @@ function plugins_quorum_Libraries_Game_WebInput_()
         
         plugins_quorum_Libraries_Game_WebInput_.ContextMenu = function(event)
         {
-            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsCanvasFocused())
+            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsFocused())
             {
                 if (plugins_quorum_Libraries_Game_WebInput_.disableContextMenu)
                 {

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
@@ -7,6 +7,23 @@ function plugins_quorum_Libraries_Interface_Accessibility_WebAccessibility_() {
     var elementType = "DIV";   //specifies the type of element DEFAULT is DIV right now for testing
     var elementList = [];   // array using the item's hashCode value as an index and the item as the value 
     var currentFocus = null;
+
+    const setBounds = (element, item) => {
+        if (global_InstanceOf(item,"Libraries.Interface.Item2D")) {
+            let item2D = global_CheckCast(item, "Libraries.Interface.Item2D");
+            let x = item2D.GetScreenX();
+            let y = item2D.GetScreenY();
+            if (!(isNaN(x) || isNaN(y))) {
+                // TODO: adjust coordinates for items with accessible parents
+                element.style.position = "absolute";
+                element.style.overflow = "hidden";
+                element.style.left = `${x}px`;
+                element.style.bottom = `${y}px`;
+                element.style.width = `${item2D.GetWidth()}px`;
+                element.style.height = `${item2D.GetHeight()}px`;
+            }
+        }
+    };
     
 //    system action NameChanged(Item item)
 
@@ -28,6 +45,17 @@ function plugins_quorum_Libraries_Interface_Accessibility_WebAccessibility_() {
             element.setAttribute("aria-description", item.GetDescription());
         }
         console.log("Description Changed");
+    };
+    
+//    system action BoundsChanged(Item item)
+
+    this.BoundsChanged$quorum_Libraries_Interface_Item = function(item) {
+        var id = item.GetHashCode();
+        if( elementList[id] != null ) {
+            var element = document.getElementById(id);
+            setBounds(element, item);
+        }
+        console.log("Bounds Changed");
     };
     
 //    system action TextFieldUpdatePassword(TextField field)
@@ -467,6 +495,8 @@ this.ToggleButtonToggled$quorum_Libraries_Interface_Controls_ToggleButton = func
                 control.Activate();
             });
         }
+
+        setBounds(para, item);
 
         //add element to a parent if need be or directly to canvas
         if (parent != undefined) {

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
@@ -19,6 +19,9 @@ function plugins_quorum_Libraries_Interface_Accessibility_WebAccessibility_() {
             root.style.bottom = 0;
             root.style.width = "100%";
             root.style.height = "100%";
+            // Ensure that bugs in the positioning of shadow elements
+            // don't affect the visible layout.
+            root.style.overflow = "hidden";
 
             // The following style settings come from Flutter Web.
             // Make all semantics transparent. We use `filter` instead of `opacity`

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
@@ -42,8 +42,30 @@ function plugins_quorum_Libraries_Interface_Accessibility_WebAccessibility_() {
             let item2D = global_CheckCast(item, "Libraries.Interface.Item2D");
             let x = item2D.GetScreenX();
             let y = item2D.GetScreenY();
+
             if (!(isNaN(x) || isNaN(y))) {
-                // TODO: adjust coordinates for items with accessible parents
+                // Find the nearest ancestor element that corresponds to an item.
+                // If there is one, we need to adjust this element's position
+                // to be relative to that ancestor.
+                let ancestor = element.parentElement;
+                while (ancestor && (ancestor !== root)) {
+                    let ancestorId = ancestor.id;
+                    if (ancestorId && elementList[ancestorId]) {
+                        let ancestorItem = elementList[ancestorId];
+                        if (global_InstanceOf(ancestorItem,"Libraries.Interface.Item2D")) {
+                            let ancestorItem2D = global_CheckCast(ancestorItem, "Libraries.Interface.Item2D");
+                            let ancestorX = ancestorItem2D.GetScreenX();
+                            let ancestorY = ancestorItem2D.GetScreenY();
+                            if (!(isNaN(ancestorX) || isNaN(ancestorY))) {
+                                x -= ancestorX;
+                                y -= ancestorY;
+                                break;
+                            }
+                        }
+                    }
+                    ancestor = ancestor.parentElement;
+                }
+
                 element.style.position = "absolute";
                 element.style.left = `${x}px`;
                 element.style.bottom = `${y}px`;
@@ -536,8 +558,6 @@ this.ToggleButtonToggled$quorum_Libraries_Interface_Controls_ToggleButton = func
             });
         }
 
-        setBounds(para, item);
-
         //add element to a parent if need be or directly to the root
         if (parent != undefined) {
             var parentElement = document.getElementById(parent);
@@ -548,6 +568,10 @@ this.ToggleButtonToggled$quorum_Libraries_Interface_Controls_ToggleButton = func
             root.appendChild(para);
             console.log(item.GetName(), " has been added.");
         }
+
+        // Set the element's bounds after we've added it, so setBounds can assume
+        // the element's parent is already set.
+        setBounds(para, item);
 };
 //    system action NativeRemove(Item item)
     this.NativeRemove$quorum_Libraries_Interface_Item = function(item) {

--- a/Quorum/Library/Tests/Game/Pass/ConstantTest.quorum
+++ b/Quorum/Library/Tests/Game/Pass/ConstantTest.quorum
@@ -9,7 +9,7 @@ class Main is Game
 
     action Main
         WebConfiguration config = GetWebConfiguration()
-        config:canvasID = "glcanvas"
+        config:containerID = "container"
         StartGame()
     end
 

--- a/Quorum/Library/Tests/Game/Pass/WebTest.quorum
+++ b/Quorum/Library/Tests/Game/Pass/WebTest.quorum
@@ -8,7 +8,7 @@ class Main is Game
     Drawable rectangle
     action Main
         WebConfiguration config = GetWebConfiguration()
-        config:canvasID = "divideIDEIdeOutput"
+        config:containerID = "divideIDEIdeOutput"
         SetScreenSize(640, 480)
         StartGame()
     end


### PR DESCRIPTION
1. The `Accessibility` base class has a new blueprint action, `BoundsChanged`, which should be called whenever the position or size of an accessible item changes.
2. `Item2D` calls this new callback whenever it changes its position or size.
3. `WebAccessibility` sets CSS positioning properties on shadow elements, both when a new element is added and in the `BoundsChanged` callback.
4. To ensure that all browsers pay attention to these positioning properties, the shadow DOM elements are now beside the canvas in the DOM tree, not under it.
5. Specifically, the shadow DOM elements are now under a single root element created by `WebAccessibility`, which is at the same level as the canvas in the tree. This lets us set several properties on the root, and it also lets us destroy the whole shadow DOM tree on shutdown by deleting just one element.
6. To allow the canvas and shadow DOM to be at the same level in the tree, Quorum now expects the embedding page to provide a single generic `div` as a container, rather than providing the canvas itself. Quorum is now responsible for creating the canvas and for setting all attributes on the container that don't depend on the layout of the containing page.