### PR TITLE
Enable column comparisons when a column contains null cells

### DIFF
--- a/Quorum/Library/Standard/Libraries/Compute/Statistics/Columns/BigIntegerColumn.quorum
+++ b/Quorum/Library/Standard/Libraries/Compute/Statistics/Columns/BigIntegerColumn.quorum
@@ -173,7 +173,7 @@ class BigIntegerColumn is DataFrameColumn
             if GetSortComparison() not= undefined
                 newRows:Sort(GetSortComparison())
             else
-                newRows:Sort()
+                newRows:Sort(me)
             end
         end
         column:rows = newRows

--- a/Quorum/Library/Standard/Libraries/Compute/Statistics/Columns/BooleanColumn.quorum
+++ b/Quorum/Library/Standard/Libraries/Compute/Statistics/Columns/BooleanColumn.quorum
@@ -206,7 +206,7 @@ class BooleanColumn is DataFrameColumn
             if GetSortComparison() not= undefined
                 newRows:Sort(GetSortComparison())
             else
-                newRows:Sort()
+                newRows:Sort(me)
             end
         end
         column:rows = newRows

--- a/Quorum/Library/Standard/Libraries/Compute/Statistics/Columns/DateTimeColumn.quorum
+++ b/Quorum/Library/Standard/Libraries/Compute/Statistics/Columns/DateTimeColumn.quorum
@@ -212,7 +212,7 @@ class DateTimeColumn is DataFrameColumn
             if GetSortComparison() not= undefined
                 newRows:Sort(GetSortComparison())
             else
-                newRows:Sort()
+                newRows:Sort(me)
             end
         end
         column:rows = newRows

--- a/Quorum/Library/Standard/Libraries/Compute/Statistics/Columns/IntegerColumn.quorum
+++ b/Quorum/Library/Standard/Libraries/Compute/Statistics/Columns/IntegerColumn.quorum
@@ -230,7 +230,7 @@ class IntegerColumn is DataFrameColumn
             if GetSortComparison() not= undefined
                 newRows:Sort(GetSortComparison())
             else
-                newRows:Sort()
+                newRows:Sort(me)
             end
         end
         column:rows = newRows

--- a/Quorum/Library/Standard/Libraries/Compute/Statistics/Columns/NumberColumn.quorum
+++ b/Quorum/Library/Standard/Libraries/Compute/Statistics/Columns/NumberColumn.quorum
@@ -232,7 +232,7 @@ class NumberColumn is DataFrameColumn
             if GetSortComparison() not= undefined
                 newRows:Sort(GetSortComparison())
             else
-                newRows:Sort()
+                newRows:Sort(me)//otherwise override it with my default
             end
         end
         column:rows = newRows

--- a/Quorum/Library/Standard/Libraries/Compute/Statistics/Columns/TextColumn.quorum
+++ b/Quorum/Library/Standard/Libraries/Compute/Statistics/Columns/TextColumn.quorum
@@ -179,7 +179,7 @@ class TextColumn is DataFrameColumn
             if GetSortComparison() not= undefined
                 newRows:Sort(GetSortComparison())
             else
-                newRows:Sort()
+                newRows:Sort(me)
             end
         end
         column:rows = newRows

--- a/Quorum/Library/Standard/Libraries/Compute/Statistics/DataFrameColumn.quorum
+++ b/Quorum/Library/Standard/Libraries/Compute/Statistics/DataFrameColumn.quorum
@@ -40,7 +40,7 @@ use Libraries.Language.Compile.Interpreter.Result
     DataFrameColumn col = frame:GetColumn(0)
     output col:ToText()
 */
-class DataFrameColumn 
+class DataFrameColumn is Comparison
     /* This is the name of the column. */
     text header = ""
     integer undefinedSize = 0
@@ -576,5 +576,19 @@ class DataFrameColumn
     */
     action SetSortComparison(Comparison comparison)
         me:comparison = comparison
+    end
+
+    action Compare(Object a, Object b) returns integer
+        //first handle the case where items are undefined
+        if a = undefined and b = undefined
+            return 0
+        elseif a = undefined and b not= undefined
+            return -1
+        elseif a not= undefined and b = undefined
+            return 1
+        end
+
+        //both items are defined, so now do the normal sort
+        return a:Compare(b)
     end
 end


### PR DESCRIPTION
This handles column comparisons when the DataFrame contains null cells. Updated BigInteger, Boolean, DateTime, Integer, Number, and Text column types.