### PR TITLE
Fix keyboard not appearing on iOS TextFields and TextBoxes

### DIFF
--- a/Plugins/QuorumPlugins/src/main/java/plugins/quorum/Libraries/Interface/Accessibility/IOS/TextBoxIOS.java
+++ b/Plugins/QuorumPlugins/src/main/java/plugins/quorum/Libraries/Interface/Accessibility/IOS/TextBoxIOS.java
@@ -17,7 +17,10 @@ public class TextBoxIOS extends TextAdjust{
     }
 
     public void Initialize(TextField_ field) {
-        UIAccessibilityTraits traits = UIAccessibilityTraits.SearchField;
+        // Use UIAccessibilityTraits.None instead of SearchField to ensure activate() is called
+        // when VoiceOver is disabled. SearchField trait doesn't trigger activate() on tap
+        // when the screen reader is off, but None does (matching behavior of other UI Elements).
+        UIAccessibilityTraits traits = UIAccessibilityTraits.None;
         this.setAccessibilityTraits(traits);
         super.Initialize(field);
     }
@@ -34,6 +37,11 @@ public class TextBoxIOS extends TextAdjust{
         input.setOnscreenKeyboardVisible(false);
     }
 
+    /**
+     * Called by iOS when the accessibility element is activated (tapped) while VoiceOver is disabled.
+     * When VoiceOver is enabled, iOS uses didBecomeFocused() instead. This method ensures the keyboard
+     * appears when users tap on text boxes without VoiceOver enabled.
+     */
     @Override
     public boolean activate() {
         Focus();

--- a/Plugins/QuorumPlugins/src/main/java/plugins/quorum/Libraries/Interface/Accessibility/IOS/TextBoxIOS.java
+++ b/Plugins/QuorumPlugins/src/main/java/plugins/quorum/Libraries/Interface/Accessibility/IOS/TextBoxIOS.java
@@ -34,6 +34,12 @@ public class TextBoxIOS extends TextAdjust{
         input.setOnscreenKeyboardVisible(false);
     }
 
+    @Override
+    public boolean activate() {
+        Focus();
+        return true;
+    }
+
     public TextBox_ GetTextBox() {
         TextBox_ box = (TextBox_) GetItem();
         return box;

--- a/Plugins/QuorumPlugins/src/main/java/plugins/quorum/Libraries/Interface/Accessibility/IOS/TextFieldIOS.java
+++ b/Plugins/QuorumPlugins/src/main/java/plugins/quorum/Libraries/Interface/Accessibility/IOS/TextFieldIOS.java
@@ -18,7 +18,10 @@ public class TextFieldIOS extends TextAdjust implements UIKeyInput, UITextInputT
     }
 
     public void Initialize(TextField_ field) {
-        UIAccessibilityTraits traits = UIAccessibilityTraits.SearchField;
+        // Use UIAccessibilityTraits.None instead of SearchField to ensure activate() is called
+        // when VoiceOver is disabled. SearchField trait doesn't trigger activate() on tap
+        // when the screen reader is off, but None does (matching behavior of UI Elements).
+        UIAccessibilityTraits traits = UIAccessibilityTraits.None;
         this.setAccessibilityTraits(traits);
         super.Initialize(field);
     }
@@ -55,6 +58,11 @@ public class TextFieldIOS extends TextAdjust implements UIKeyInput, UITextInputT
         input.setOnscreenKeyboardVisible(false);
     }
 
+    /**
+     * Called by iOS when the accessibility element is activated (tapped) while VoiceOver is disabled.
+     * When VoiceOver is enabled, iOS uses didBecomeFocused() instead. This method ensures the keyboard
+     * appears when users tap on text fields without VoiceOver enabled.
+     */
     @Override
     public boolean activate() {
         Focus();

--- a/Plugins/QuorumPlugins/src/main/java/plugins/quorum/Libraries/Interface/Accessibility/IOS/TextFieldIOS.java
+++ b/Plugins/QuorumPlugins/src/main/java/plugins/quorum/Libraries/Interface/Accessibility/IOS/TextFieldIOS.java
@@ -56,6 +56,12 @@ public class TextFieldIOS extends TextAdjust implements UIKeyInput, UITextInputT
     }
 
     @Override
+    public boolean activate() {
+        Focus();
+        return true;
+    }
+
+    @Override
     public boolean hasText() {
         return true;
     }


### PR DESCRIPTION
Fixes an issue where tapping on **TextFieldIOS** and **TextBoxIOS** did not open the keyboard when **VoiceOver was disabled**.
Adds `activate()` overrides and updates the accessibility traits so both controls receive focus and trigger the keyboard correctly.