### PR TITLE
Fix buttons not showing focus or visual feedback on iOS when VoiceOver is off

### DIFF
--- a/Plugins/QuorumPlugins/src/main/java/plugins/quorum/Libraries/Interface/Accessibility/IOS/ButtonIOS.java
+++ b/Plugins/QuorumPlugins/src/main/java/plugins/quorum/Libraries/Interface/Accessibility/IOS/ButtonIOS.java
@@ -30,9 +30,43 @@ public class ButtonIOS extends ItemIOS {
         super.Initialize(button);
     }
 
+    /**
+     * Called when the button is activated.
+     * When buttons are activated, they should show visual feedback.
+     */
     @Override
     public boolean activate() {
-        button.Activate();
+        if (button != null) {
+            // Give the button focus so it shows visual feedback
+            button.Focus();
+            // Mirror the Quorum button click so visual state updates
+            button.SetDepression(true);
+            button.ClickedMouse();
+            button.SetDepression(false);
+            button.Activate();
+        }
         return true;
+    }
+
+    /**
+     * Called when accessibility focus moves to this button.
+     */
+    @Override
+    public void Focus() {
+        super.Focus();
+        if (button != null) {
+            // Give the button Quorum focus so it shows the focus visual state
+            button.Focus();
+        }
+    }
+
+    /**
+     * Called when accessibility focus leaves this button.
+     * Manually clear focus.
+     */
+    @Override
+    public void FocusLost() {
+        // The button's LostFocus will be called by the focus manager
+        super.FocusLost();
     }
 }


### PR DESCRIPTION
Fixes an issue where tapping on ButtonIOS did not show focus or visual feedback when VoiceOver was disabled.
Adds focus handling and visual feedback inside Activate(), and overrides Focus() and FocusLost() so the button receives focus and updates its visual state correctly on taps.